### PR TITLE
Allow environment variables in the path

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -138,3 +138,12 @@ For example, in a :code:`bash` terminal,
     export DUSTMAPS_CONFIG_FNAME=/path/to/custom/config/file.json
     python script_using_dustmaps.py
 
+The paths listed in the configuration file can also include environmental
+variables, which will be expanded when :code:`dustmaps` is loaded. For example,
+the configuration file could contain the following::
+
+    {"data_dir": "/path/with/${VARIABLE}/included"}
+
+If the environmental variable :code:`VARIABLE` is set to :code:`"foo"`,
+for example, then :code:`dustmaps` will expand :code:`data_dir` to
+:code:`"/path/with/foo/included"`.

--- a/dustmaps/config.py
+++ b/dustmaps/config.py
@@ -40,6 +40,10 @@ class Configuration(object):
 
     This can be overridden by setting the environmental variable
     :obj:`DUSTMAPS_CONFIG_FNAME`.
+
+    Paths stored in the configuration file (such as the data
+    directory, :obj:`data_dir`, can include environmental
+    variables, which will be expanded.
     """
 
     def __init__(self, fname):

--- a/dustmaps/std_paths.py
+++ b/dustmaps/std_paths.py
@@ -34,7 +34,8 @@ output_dir_default = os.path.abspath(os.path.join(script_dir, 'output'))
 
 def fix_path(path):
     """
-    Returns an absolute path, with '~' expanded to the user's home directory.
+    Returns an absolute path, expanding both '~' (to the user's home
+    directory) and other environmental variables in the path.
     """
     return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
 

--- a/dustmaps/std_paths.py
+++ b/dustmaps/std_paths.py
@@ -36,7 +36,7 @@ def fix_path(path):
     """
     Returns an absolute path, with '~' expanded to the user's home directory.
     """
-    return os.path.abspath(os.path.expanduser(path))
+    return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
 
 
 def data_dir():

--- a/dustmaps/tests/test_config.py
+++ b/dustmaps/tests/test_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-# test_override_config.py
-# Test code to override default config location
+# test_config.py
+# Test code related to the configuration submodule.
 #
 # Copyright (C) 2016  Gregory M. Green
 #
@@ -50,6 +50,36 @@ class TestConfig(unittest.TestCase):
         del os.environ['DUSTMAPS_CONFIG_FNAME']
         del sys.modules['dustmaps.config']
         from ..config import config
+
+    def test_config_with_envvar(self):
+        """
+        Test expansion of environmental variables in directory paths.'
+        """
+        # Set the environment variable DUSTMAPS_CONFIG_FNAME
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        os.environ['DUSTMAPS_CONFIG_FNAME'] = os.path.join(test_dir, 'test_config_with_envvar.json')
+
+        # Set an environmental variable in the config path
+        os.environ['VARIABLE_TO_BE_EXPANDED'] = 'expanded_variable'
+
+        # Reset the dustmaps.config module
+        if 'dustmaps.config' in sys.modules:
+            print('Unloading config module ...')
+            del sys.modules['dustmaps.config']
+            print('Unloading std_paths module ...')
+            del sys.modules['dustmaps.std_paths']
+        from ..config import config
+        from ..std_paths import data_dir
+
+        # Check that the data directory has been loaded from the test config file
+        self.assertEqual(data_dir(), '/path/with/expanded_variable')
+
+        # Reset the dustmaps.config module, in case other tests need it
+        del os.environ['DUSTMAPS_CONFIG_FNAME']
+        del sys.modules['dustmaps.config']
+        del sys.modules['dustmaps.std_paths']
+        from ..config import config
+        from ..std_paths import data_dir
 
 
 if __name__ == '__main__':

--- a/dustmaps/tests/test_config_with_envvar.json
+++ b/dustmaps/tests/test_config_with_envvar.json
@@ -1,0 +1,1 @@
+{"data_dir": "/path/with/${VARIABLE_TO_BE_EXPANDED}"}

--- a/setup.py
+++ b/setup.py
@@ -148,12 +148,12 @@ def readme():
 
 setup(
     name='dustmaps',
-    version='1.0.5',
+    version='1.0.6',
     description='Uniform interface for multiple dust reddening maps.',
     long_description=readme(),
     long_description_content_type='text/markdown',
     url='https://github.com/gregreen/dustmaps',
-    download_url='https://github.com/gregreen/dustmaps/archive/v1.0.5.tar.gz',
+    download_url='https://github.com/gregreen/dustmaps/archive/v1.0.6.tar.gz',
     author='Gregory M. Green',
     author_email='gregorymgreen@gmail.com',
     license='GPLv2',


### PR DESCRIPTION
Our packaging system allows every package to set an environment variable pointing to its location.  We would like to distribute a package containing the cached dust maps so that not every user must cache the maps.  We do not know the absolute path to root install, but do know the environment variable with the path of the package containing the data.

Allowing environment variables in the `data_dir` path string would allow us to distribute and set up `dustmaps` to our users without any intervention on their end.