### PR TITLE
Fix SkyCoord.representation issue

### DIFF
--- a/dustmaps/json_serializers.py
+++ b/dustmaps/json_serializers.py
@@ -269,6 +269,7 @@ def serialize_skycoord(o):
     try:
         representation_type = o.representation_type
     except AttributeError:
+        # Very old versions of astropy do not use `representation_type`
         representation_type = o.representation
     representation = representation_type.get_name()
     frame = o.frame.name
@@ -303,10 +304,20 @@ def deserialize_skycoord(d):
     else:
         args = (d['lon'], d['lat'])
 
-    return coords.SkyCoord(
-        *args,
-        frame=d['frame'],
-        representation='spherical')
+    try:
+        c = coords.SkyCoord(
+            *args,
+            frame=d['frame'],
+            representation_type='spherical'
+        )
+    except ValueError as err:
+        # Very old versions of astropy do not use `representation_type`
+        c = coords.SkyCoord(
+            *args,
+            frame=d['frame'],
+            representation='spherical'
+        )
+    return c
 
 
 def get_encoder(ndarray_mode='b64'):

--- a/dustmaps/json_serializers.py
+++ b/dustmaps/json_serializers.py
@@ -266,7 +266,11 @@ def serialize_skycoord(o):
     Returns:
         A dictionary that can be passed to :obj:`json.dumps`.
     """
-    representation = o.representation.get_name()
+    try:
+        representation_type = o.representation_type
+    except AttributeError:
+        representation_type = o.representation
+    representation = representation_type.get_name()
     frame = o.frame.name
 
     r = o.represent_as('spherical')


### PR DESCRIPTION
This fixes the issue caused by SkyCoord.representation removal in astropy 5. I'm not sure if we need to hold a fallback to the old `.representation` attribute: `.representation_type` was introduced in `astropy` v3, which was the last version supporting EOLed python 3.6.

Fix #37