### PR TITLE
Expand SFDQuery to include mask and other data products

### DIFF
--- a/dustmaps/sfd.py
+++ b/dustmaps/sfd.py
@@ -138,9 +138,8 @@ class SFDQuery(SFDBase):
         
         For whichparent ``SFD`` and which ``i60``, the map is the Schlegel, Finkbeiner & Davis (1998) 60 micron intensity map (MJy/sr).
         
-        # check bit 0/1 oddness ##FIXME
         For whichparent ``SFD`` and which ``mask``, the map is the Schlegel, Finkbeiner & Davis (1998) bit mask map.
-            Bit 0, 1: Number of HCONs (0, 1, 2, or 3)
+            Bit 0, 1: The first two bits express (in binary) the number of HCONs (0, 1, 2, or 3)
             Bit 2: Asteroid removed
             Bit 3: Small no-data region replaced
             Bit 4: Source removed (any)

--- a/dustmaps/sfd.py
+++ b/dustmaps/sfd.py
@@ -99,7 +99,12 @@ class SFDQuery(SFDBase):
     map_name = 'sfd'
     map_name_long = "SFD'98"
 
-    def __init__(self, map_dir=None):
+    def __init__(
+        self, 
+        map_dir=None,
+        whichparent='SFD',
+        which='dust'
+    ):
         """
         Args:
             map_dir (Optional[str]): The directory containing the SFD map.
@@ -110,7 +115,10 @@ class SFDQuery(SFDBase):
         if map_dir is None:
             map_dir = os.path.join(data_dir(), 'sfd')
 
-        base_fname = os.path.join(map_dir, 'SFD_dust_4096')
+        if whichparent == 'SFD':
+            base_fname = os.path.join(map_dir, '{}_{}_4096'.format(whichparent,which))
+        else:
+            base_fname = os.path.join(map_dir, '{}_{}'.format(whichparent,which))
         
         super(SFDQuery, self).__init__(base_fname)
     
@@ -149,19 +157,30 @@ class SFDWebQuery(WebDustMap):
             map_name='sfd')
 
 
-def fetch():
+def fetch(whichparent='SFD',which='dust'):
     """
     Downloads the Schlegel, Finkbeiner & Davis (1998) dust map, placing it in
     the data directory for `dustmap`.
+    
+    Args:
+        which (Optional[:obj:`str`]): The name of the SFD data product to download.
+            Should be either ``dust`` (the default), ``i100``, ``i60``, ``mask``, ``temp``, or ``xmap``.
     """
     doi = '10.7910/DVN/EWCNL5'
 
     for pole in ['ngp', 'sgp']:
-        requirements = {'filename': 'SFD_dust_4096_{}.fits'.format(pole)}
-        local_fname = os.path.join(
+        if whichparent == 'SFD':
+            requirements = {'filename': '{}_{}_4096_{}.fits'.format(whichparent,which,pole)}
+            local_fname = os.path.join(
             data_dir(),
-            'sfd', 'SFD_dust_4096_{}.fits'.format(pole))
-        print('Downloading SFD data file to {}'.format(local_fname))
+            'sfd', '{}_{}_4096_{}.fits'.format(whichparent,which,pole))
+        else:
+            requirements = {'filename': '{}_{}_{}.fits'.format(whichparent,which,pole)}
+            local_fname = os.path.join(
+            data_dir(),
+            'sfd', '{}_{}_{}.fits'.format(whichparent,which,pole))
+
+        print('Downloading {} {} data file to {}'.format(whichparent,which,local_fname))
         fetch_utils.dataverse_download_doi(
             doi,
             local_fname,

--- a/dustmaps/sfd.py
+++ b/dustmaps/sfd.py
@@ -115,7 +115,7 @@ class SFDQuery(SFDBase):
         if map_dir is None:
             map_dir = os.path.join(data_dir(), 'sfd')
 
-        if whichparent == 'SFD':
+        if (whichparent == 'SFD') and (which == 'dust' or which == 'i100' or which == 'i60' or which == 'mask'):
             base_fname = os.path.join(map_dir, '{}_{}_4096'.format(whichparent,which))
         else:
             base_fname = os.path.join(map_dir, '{}_{}'.format(whichparent,which))
@@ -169,7 +169,7 @@ def fetch(whichparent='SFD',which='dust'):
     doi = '10.7910/DVN/EWCNL5'
 
     for pole in ['ngp', 'sgp']:
-        if whichparent == 'SFD':
+        if (whichparent == 'SFD') and (which == 'dust' or which == 'i100' or which == 'i60' or which == 'mask'):
             requirements = {'filename': '{}_{}_4096_{}.fits'.format(whichparent,which,pole)}
             local_fname = os.path.join(
             data_dir(),

--- a/dustmaps/sfd.py
+++ b/dustmaps/sfd.py
@@ -125,7 +125,10 @@ class SFDQuery(SFDBase):
             base_fname = os.path.join(map_dir, '{}_{}'.format(whichparent,which))
         
         super(SFDQuery, self).__init__(base_fname)
+        self.which = which
+        self.whichparent = whichparent
     
+    #FIXME force order to 0 if bit mask (check CFSD)
     def query(self, coords, order=1):
         """
         Returns value of SFD-style map defined by ``whichparent`` and ``which`` during the intialization of the `SFDQuery` object at the specified location(s) on the sky.
@@ -153,11 +156,9 @@ class SFDQuery(SFDBase):
         
         For whichparent ``FINK`` and which ``Rmap``, the map is the Finkbeiner-Davis-Schlegel (1999) DIRBE 100/240mu RATIO map. This map is described in "Extrapolation of Galactic Dust Emission at 100 Microns to CMBR Frequencies using FIRAS" by Finkbeiner, Davis, & Schlegel (1999). Please note that this 100/240mu R map differs from the R map described in Schlegel, Finkbeiner, & Davis, ApJ 500, 525 (1998).
         
-        # check citation ##FIXME
-        For whichparent ``Haslam`` and which ``clean``, the map is the Haslam et al. (1982) 408 MHz all-sky continuum survey, cleaned of bright sources (K).The map has bright point sources removed, and has been Fourier destriped using a method similar to that applied to the IRAS/ISSA data in Schlegel, Finkbeiner, & Davis 1998, Apj, 500, 525. Due to this reprocessing, the effective beam (PSF) of the map has increased from 0.85 deg to 1.0 deg. A CMB monopole (2.73K) has been subtracted from the map. 
+        For whichparent ``Haslam`` and which ``clean``, the map is an unpublished version of the Haslam et al. (1982) 408 MHz all-sky continuum survey, cleaned of bright sources (K). The map has bright point sources removed, and has been Fourier destriped using a method similar to that applied to the IRAS/ISSA data in Schlegel, Finkbeiner, & Davis 1998, Apj, 500, 525. Due to this reprocessing, the effective beam (PSF) of the map has increased from 0.85 deg to 1.0 deg. A CMB monopole (2.73K) has been subtracted from the map. 
         
-        # check citation ##FIXME
-        For whichparent ``Synch`` and which ``Beta``, the map is the Finkbeiner & Davis (1999) synchrotron spectral index map. This map is based on the 408 MHz Haslam et al. (1982) map, 1.42 GHz Reich & Reich (1986) map, and 2.326 GHz Jonas, Baart, & Nicolson (1998) map.
+        For whichparent ``Synch`` and which ``Beta``, the map is an unpublished work by Finkbeiner & Davis (1999) to derive a synchrotron spectral index map. This map is based on the 408 MHz Haslam et al. (1982) map, 1.42 GHz Reich & Reich (1986) map, and 2.326 GHz Jonas, Baart, & Nicolson (1998) map.
 
         Args:
             coords (`astropy.coordinates.SkyCoord`): The coordinates to query.
@@ -168,6 +169,8 @@ class SFDQuery(SFDBase):
             A float array containing the values of SFD-style map at every input coordinate. The shape of the output will be the same as the shape of the
             coordinates stored by `coords`.
         """
+        if self.which == "mask":
+            order = 0 # interpolating a mask is not allowed!
         return super(SFDQuery, self).query(coords, order=order)
     
 


### PR DESCRIPTION
This PR allows users to query the SFD bitmask as well as all other SFD style data products stored on the Harvard Dataverse under the same DOI. The bitmask is forced to use order 0 interpolation to avoid violating the bit quantization. It appears that the padding done to the data to try to handle distortions at the Galactic Plane was not as successfully applied to the mask data product, leading to some artifacts near b = 0. However, it appears that this is a faithful reproduction of the values in the FITS file and the WCS header and so I am not really in favor of changing it at this level. A lower level change to better handle the distortions etc. would be preferable. In total, I think making these data products, especially the bitmask, is extremely valuable.