### PR TITLE
Add support to set default .dustmapsrc location

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -140,13 +140,18 @@ can enter the commands
 3. Custom configuration file location (Optional)
 ------------------------------------------------
 
-By default, a configuration file is stored in :code:`~/.dustmapsrc`. This 
-file might look like the following::
+By default, a configuration file is stored at the location given by
+the environment variable :code:`DUSTMAPS_DEFAULT_CONFIG_FNAME`, defaulting to
+:code:`~/.dustmapsrc` if not set.
+This file might look like the following::
 
     {"data_dir": "/path/to/store/maps/in"}
 
-If you would like :code:`dustmaps` to use a different configuration file, 
-then you can set the environmental variable :code:`DUSTMAPS_CONFIG_FNAME`. 
+If you would like :code:`dustmaps` to use a different configuration file,
+then you can either set the environmental variable
+:code:`DUSTMAPS_DEFAULT_CONFIG_FNAME` to the new path, or set the environment
+variable :code:`DUSTMAPS_CONFIG_FNAME` to override this configuration
+temporarily and print a log message.
 For example, in a :code:`bash` terminal,
 
 .. code-block :: bash

--- a/dustmaps/config.py
+++ b/dustmaps/config.py
@@ -144,14 +144,17 @@ class Configuration(object):
 
 
 # The package configuration filename
-default_config_fname = os.path.expanduser('~/.dustmapsrc')
+default_config_fname = os.environ.get('DUSTMAPS_DEFAULT_CONFIG_FNAME', '~/.dustmapsrc')
+default_config_fname = os.path.expanduser(default_config_fname)
 config_fname = os.environ.get('DUSTMAPS_CONFIG_FNAME', default_config_fname)
 if default_config_fname != config_fname:
     print('Overriding default configuration file with {}'.format(config_fname))
 
-# The package configuration. By default, this is read from ``~/.dustmapsrc``.
-# The default location can be overridden by setting the ``DUSTMAPS_CONFIG_FNAME``
-# environment variable.
+# The package configuration. By default, this is read from the
+# ``DUSTMAPS_DEFAULT_CONFIG_FNAME`` environment variable if set, and from
+# ``~/.dustmapsrc`` if not.
+# The location can be temporarily overridden with a message by setting the
+# ``DUSTMAPS_CONFIG_FNAME`` environment variable.
 #
 # This is the object that the user should interact with in order to change
 # settings. For example, to set the directory where large files (e.g., dust maps)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ class InstallCommand(install):
     def run(self):
         if not self.large_data_dir is None:
             print('Large data directory is set to: {}'.format(self.large_data_dir))
-            with open(os.path.expanduser('~/.dustmapsrc'), 'w') as f:
+            default_config_fname = os.environ.get('DUSTMAPS_DEFAULT_CONFIG_FNAME', '~/.dustmapsrc')
+            with open(os.path.expanduser(default_config_fname), 'w') as f:
                 json.dump({'data_dir': self.large_data_dir}, f, indent=2)
 
         # install.do_egg_install(self) # Due to bug in setuptools that causes old-style install


### PR DESCRIPTION
This commit adds support for setting the default location of the dustmaps configuration file via a new DUSTMAPS_DEFAULT_CONFIG_FNAME environment variable.
This will allow interested parties to prevent the warning message "Overriding default configuration file with XYZ" each time this package is imported, preventing unnecessary build-up of these log messages when used at scale.