### PR TITLE
Fix AstropyDeprecationWarning: use .name instead of .get_name()

### DIFF
--- a/dustmaps/json_serializers.py
+++ b/dustmaps/json_serializers.py
@@ -267,7 +267,11 @@ def serialize_skycoord(o):
     except AttributeError:
         # Very old versions of astropy do not use `representation_type`
         representation_type = o.representation
-    representation = representation_type.get_name()
+    # .name was introduced in astropy 7.1 (replacing the deprecated .get_name())
+    if hasattr(representation_type, 'name'):
+        representation = representation_type.name
+    else:
+        representation = representation_type.get_name()
     frame = o.frame.name
 
     r = o.represent_as('spherical')


### PR DESCRIPTION
representation_type.get_name() was deprecated in astropy v7.1 in favour of the .name class attribute. Use .name when available (astropy >= 7.1), falling back to .get_name() for older versions that predate .name.

Tested with astropy 5.0.5 (oldest with aarch64 wheels, Python 3.8) and astropy 7.1.0 (Python 3.11) with -W error::DeprecationWarning.